### PR TITLE
fix for node 0.11.15

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -228,6 +228,7 @@ OAuthStrategy.prototype.authenticate = function(req, options) {
       var parsed = url.parse(self._userAuthorizationURL, true);
       parsed.query.oauth_token = token;
       utils.merge(parsed.query, self.userAuthorizationParams(options));
+      delete parsed.path;
       delete parsed.search;
       var location = url.format(parsed);
       self.redirect(location);


### PR DESCRIPTION
If `pathname` (for `url.format()`) is present, `path` eats the `query`.

See joyent/node#9070

As a side note: they are discussing about reverting this change.