### PR TITLE
Refactored custom error constructors to work in strict mode

### DIFF
--- a/lib/errors/internaloautherror.js
+++ b/lib/errors/internaloautherror.js
@@ -12,8 +12,8 @@
  */
 function InternalOAuthError(message, err) {
   Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
-  this.name = 'InternalOAuthError';
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
   this.message = message;
   this.oauthError = err;
 }


### PR DESCRIPTION
This change is needed in order to make your code work in strict mode.