### PR TITLE
Add callbackURL to request params

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -229,6 +229,11 @@ OAuthStrategy.prototype.authenticate = function(req, options) {
       parsed.query.oauth_token = token;
       utils.merge(parsed.query, self.userAuthorizationParams(options));
       delete parsed.search;
+      // As mentiond above, cabllbackURL should be set
+      // if confirmed on server response.
+      if( params.oauth_callback_confirmed && callbackURL ){
+        parsed.query.oauth_callback = callbackURL;
+      }
       var location = url.format(parsed);
       self.redirect(location);
     });


### PR DESCRIPTION
It seems that:

- Current request param looses redirect URL even if it's set.
- So your user can't come back to your application.

This problem seems to have something with [this issue](https://github.com/jaredhanson/passport-oauth/issues/26) of [passport-oauth](https://github.com/jaredhanson/passport-oauth).

I tried OAuth 1.0a ready [WordPress' OAuth Rest server](https://github.com/justingreerbbi/wordpress-oauth-server) and confirmed this patch will fix it. Test passed.