### PR TITLE
Application-level state

### DIFF
--- a/lib/requesttoken/state.js
+++ b/lib/requesttoken/state.js
@@ -1,0 +1,41 @@
+function SessionStore(options) {
+  if (!options.key) { throw new TypeError('Session-based request token store requires a session key'); }
+  this._key = options.key;
+}
+
+SessionStore.prototype.get = function(req, token, cb) {
+  if (!req.session) { return cb(new Error('OAuth authentication requires session support. Did you forget to use express-session middleware?')); }
+  
+  // Bail if the session does not contain the request token and corresponding
+  // secret.  If this happens, it is most likely caused by initiating OAuth
+  // from a different host than that of the callback endpoint (for example:
+  // initiating from 127.0.0.1 but handling callbacks at localhost).
+  if (!req.session[this._key]) { return cb(new Error('Failed to find request token in session')); }
+  
+  var tokenSecret = req.session[this._key].oauth_token_secret;
+  var state = req.session[this._key].state;
+  return cb(null, tokenSecret, state);
+};
+
+SessionStore.prototype.set = function(req, token, tokenSecret, state, meta, cb) {
+  if (!req.session) { return cb(new Error('OAuth authentication requires session support. Did you forget to use express-session middleware?')); }
+  
+  if (!req.session[this._key]) { req.session[this._key] = {}; }
+  req.session[this._key].oauth_token = token;
+  req.session[this._key].oauth_token_secret = tokenSecret;
+  if (state) { req.session[this._key].state = state; }
+  cb();
+};
+
+SessionStore.prototype.destroy = function(req, token, cb) {
+  delete req.session[this._key].oauth_token;
+  delete req.session[this._key].oauth_token_secret;
+  delete req.session[this._key].state;
+  if (Object.keys(req.session[this._key]).length === 0) {
+    delete req.session[this._key];
+  }
+  cb();
+};
+
+
+module.exports = SessionStore;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -5,6 +5,7 @@ var passport = require('passport-strategy')
   , utils = require('./utils')
   , OAuth = require('oauth').OAuth
   , SessionRequestTokenStore = require('./requesttoken/session')
+  , StateStore = require('./requesttoken/state')
   , InternalOAuthError = require('./errors/internaloautherror');
 
 
@@ -98,7 +99,11 @@ function OAuthStrategy(options, verify) {
   this._userAuthorizationURL = options.userAuthorizationURL;
   this._callbackURL = options.callbackURL;
   this._key = options.sessionKey || 'oauth';
-  this._requestTokenStore = options.requestTokenStore || new SessionRequestTokenStore({ key: this._key });
+  if (options.store == true) {
+    this._requestTokenStore = new StateStore({ key: this._key })
+  } else {
+    this._requestTokenStore = options.requestTokenStore || new SessionRequestTokenStore({ key: this._key });
+  }
   this._trustProxy = options.proxy;
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -4,7 +4,7 @@ var passport = require('passport-strategy')
   , util = require('util')
   , utils = require('./utils')
   , OAuth = require('oauth').OAuth
-  , SessionRequestTokenStore = require('./requesttoken/session')
+  , TokenStore = require('./requesttoken/session')
   , StateStore = require('./requesttoken/state')
   , InternalOAuthError = require('./errors/internaloautherror');
 
@@ -105,7 +105,7 @@ function OAuthStrategy(options, verify) {
   } else if (store) {
     this._requestTokenStore = new StateStore({ key: this._key })
   } else {
-    this._requestTokenStore = new SessionRequestTokenStore({ key: this._key });
+    this._requestTokenStore = new TokenStore({ key: this._key });
   }
   this._trustProxy = options.proxy;
   this._passReqToCallback = options.passReqToCallback;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -99,10 +99,13 @@ function OAuthStrategy(options, verify) {
   this._userAuthorizationURL = options.userAuthorizationURL;
   this._callbackURL = options.callbackURL;
   this._key = options.sessionKey || 'oauth';
-  if (options.store == true) {
+  var store = options.store || options.requestTokenStore;
+  if (store && typeof store == 'object') {
+    this._requestTokenStore = store;
+  } else if (store) {
     this._requestTokenStore = new StateStore({ key: this._key })
   } else {
-    this._requestTokenStore = options.requestTokenStore || new SessionRequestTokenStore({ key: this._key });
+    this._requestTokenStore = new SessionRequestTokenStore({ key: this._key });
   }
   this._trustProxy = options.proxy;
   this._passReqToCallback = options.passReqToCallback;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -247,6 +247,8 @@ OAuthStrategy.prototype.authenticate = function(req, options) {
       //       true, if the server supports OAuth 1.0a.
       //       { oauth_callback_confirmed: 'true' }
 
+      var state = options.state;
+
       function stored(err) {
         if (err) { return self.error(err); }
 
@@ -267,7 +269,9 @@ OAuthStrategy.prototype.authenticate = function(req, options) {
 
       try {
         var arity = self._requestTokenStore.set.length;
-        if (arity == 5) {
+        if (arity == 6) {
+          self._requestTokenStore.set(req, token, tokenSecret, state, meta, stored);
+        } else if (arity == 5) {
           self._requestTokenStore.set(req, token, tokenSecret, meta, stored);
         } else { // arity == 4
           self._requestTokenStore.set(req, token, tokenSecret, stored);

--- a/test/oauth.state.test.js
+++ b/test/oauth.state.test.js
@@ -1,0 +1,280 @@
+var OAuthStrategy = require('../lib/strategy')
+  , InternalOAuthError = require('../lib/errors/internaloautherror')
+  , chai = require('chai');
+
+
+describe('OAuthStrategy', function() {
+  
+  describe('issuing authorization request with state store', function() {
+    
+    describe('that redirects to service provider without state', function() {
+      var strategy = new OAuthStrategy({
+        requestTokenURL: 'https://www.example.com/oauth/request_token',
+        accessTokenURL: 'https://www.example.com/oauth/access_token',
+        userAuthorizationURL: 'https://www.example.com/oauth/authorize',
+        consumerKey: 'ABC123',
+        consumerSecret: 'secret',
+        store: true
+      }, function() {});
+    
+      strategy._oauth.getOAuthRequestToken = function(extraParams, callback) {
+        if (Object.keys(extraParams).length !== 1) { return callback(new Error('incorrect extraParams argument')); }
+        if (extraParams.oauth_callback !== undefined) { return callback(new Error('incorrect oauth_callback argument')); }
+    
+        callback(null, 'hh5s93j4hdidpola', 'hdhd0244k9j7ao03', {});
+      }
+    
+    
+      var request
+        , url;
+  
+      before(function(done) {
+        chai.passport.use(strategy)
+          .redirect(function(u) {
+            url = u;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+            req.session = {};
+          })
+          .authenticate();
+      });
+  
+      it('should be redirected', function() {
+        expect(url).to.equal('https://www.example.com/oauth/authorize?oauth_token=hh5s93j4hdidpola');
+      });
+    
+      it('should store token and token secret in session', function() {
+        expect(request.session['oauth']).to.not.be.undefined;
+        expect(request.session['oauth']['oauth_token']).to.equal('hh5s93j4hdidpola');
+        expect(request.session['oauth']['oauth_token_secret']).to.equal('hdhd0244k9j7ao03');
+        expect(request.session['oauth']['state']).to.be.undefined;
+      });
+    }); // that redirects to service provider without state
+    
+    describe('that redirects to service provider with state', function() {
+      var strategy = new OAuthStrategy({
+        requestTokenURL: 'https://www.example.com/oauth/request_token',
+        accessTokenURL: 'https://www.example.com/oauth/access_token',
+        userAuthorizationURL: 'https://www.example.com/oauth/authorize',
+        consumerKey: 'ABC123',
+        consumerSecret: 'secret',
+        store: true
+      }, function() {});
+    
+      strategy._oauth.getOAuthRequestToken = function(extraParams, callback) {
+        if (Object.keys(extraParams).length !== 1) { return callback(new Error('incorrect extraParams argument')); }
+        if (extraParams.oauth_callback !== undefined) { return callback(new Error('incorrect oauth_callback argument')); }
+    
+        callback(null, 'hh5s93j4hdidpola', 'hdhd0244k9j7ao03', {});
+      }
+    
+    
+      var request
+        , url;
+  
+      before(function(done) {
+        chai.passport.use(strategy)
+          .redirect(function(u) {
+            url = u;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+            req.session = {};
+          })
+          .authenticate({ state: { beep: 'boop' } });
+      });
+  
+      it('should be redirected', function() {
+        expect(url).to.equal('https://www.example.com/oauth/authorize?oauth_token=hh5s93j4hdidpola');
+      });
+    
+      it('should store token and token secret in session', function() {
+        expect(request.session['oauth']).to.not.be.undefined;
+        expect(request.session['oauth']['oauth_token']).to.equal('hh5s93j4hdidpola');
+        expect(request.session['oauth']['oauth_token_secret']).to.equal('hdhd0244k9j7ao03');
+        expect(request.session['oauth']['state']).to.deep.equal({ beep: 'boop' });
+      });
+    }); // that redirects to service provider with state
+    
+    describe('that errors due to lack of session support in app', function() {
+      var strategy = new OAuthStrategy({
+        requestTokenURL: 'https://www.example.com/oauth/request_token',
+        accessTokenURL: 'https://www.example.com/oauth/access_token',
+        userAuthorizationURL: 'https://www.example.com/oauth/authorize',
+        consumerKey: 'ABC123',
+        consumerSecret: 'secret',
+        store: true
+      }, function() {});
+    
+      strategy._oauth.getOAuthRequestToken = function(extraParams, callback) {
+        if (Object.keys(extraParams).length !== 1) { return callback(new Error('incorrect extraParams argument')); }
+        if (extraParams.oauth_callback !== undefined) { return callback(new Error('incorrect oauth_callback argument')); }
+    
+        callback(null, 'hh5s93j4hdidpola', 'hdhd0244k9j7ao03', {});
+      }
+    
+    
+      var request
+        , err;
+  
+      before(function(done) {
+        chai.passport.use(strategy)
+          .error(function(e) {
+            err = e;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+          })
+          .authenticate();
+      });
+  
+      it('should error', function() {
+        expect(err).to.be.an.instanceof(Error);
+        expect(err.message).to.equal('OAuth authentication requires session support. Did you forget to use express-session middleware?');
+      });
+    }); // that errors due to lack of session support in app
+    
+  });
+  
+  describe('processing response to authorization request with state store', function() {
+    
+    describe('that was approved without state', function() {
+      var strategy = new OAuthStrategy({
+        requestTokenURL: 'https://www.example.com/oauth/request_token',
+        accessTokenURL: 'https://www.example.com/oauth/access_token',
+        userAuthorizationURL: 'https://www.example.com/oauth/authorize',
+        consumerKey: 'ABC123',
+        consumerSecret: 'secret',
+        store: true
+      }, function(token, tokenSecret, profile, done) {
+        if (token != 'nnch734d00sl2jdk') { return callback(new Error('incorrect token argument')); }
+        if (tokenSecret != 'pfkkdhi9sl3r4s00') { return callback(new Error('incorrect tokenSecret argument')); }
+        if (typeof profile !== 'object') { return done(new Error('incorrect profile argument')); }
+        if (Object.keys(profile).length !== 0) { return done(new Error('incorrect profile argument')); }
+    
+        return done(null, { id: '1234' }, { message: 'Hello' });
+      });
+    
+      strategy._oauth.getOAuthAccessToken = function(token, tokenSecret, verifier, callback) {
+        if (token != 'hh5s93j4hdidpola') { return callback(new Error('incorrect token argument')); }
+        if (tokenSecret != 'hdhd0244k9j7ao03') { return callback(new Error('incorrect tokenSecret argument')); }
+        if (verifier != 'hfdp7dh39dks9884') { return callback(new Error('incorrect verifier argument')); }
+        
+        return callback(null, 'nnch734d00sl2jdk', 'pfkkdhi9sl3r4s00', {});
+      };
+    
+    
+      var request
+        , user
+        , info;
+  
+      before(function(done) {
+        chai.passport.use(strategy)
+          .success(function(u, i) {
+            user = u;
+            info = i;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+            req.query = {};
+            req.query['oauth_token'] = 'hh5s93j4hdidpola';
+            req.query['oauth_verifier'] = 'hfdp7dh39dks9884';
+            req.session = {};
+            req.session['oauth'] = {};
+            req.session['oauth']['oauth_token'] = 'hh5s93j4hdidpola';
+            req.session['oauth']['oauth_token_secret'] = 'hdhd0244k9j7ao03';
+          })
+          .authenticate();
+      });
+  
+      it('should supply user', function() {
+        expect(user).to.be.an.object;
+        expect(user.id).to.equal('1234');
+      });
+
+      it('should supply info', function() {
+        expect(info).to.be.an.object;
+        expect(info.message).to.equal('Hello');
+        expect(info.state).to.be.undefined;
+      });
+    
+      it('should remove token and token secret from session', function() {
+        expect(request.session['oauth']).to.be.undefined;
+      });
+    }); // that was approved without state
+    
+    describe('that was approved with state', function() {
+      var strategy = new OAuthStrategy({
+        requestTokenURL: 'https://www.example.com/oauth/request_token',
+        accessTokenURL: 'https://www.example.com/oauth/access_token',
+        userAuthorizationURL: 'https://www.example.com/oauth/authorize',
+        consumerKey: 'ABC123',
+        consumerSecret: 'secret',
+        store: true
+      }, function(token, tokenSecret, profile, done) {
+        if (token != 'nnch734d00sl2jdk') { return callback(new Error('incorrect token argument')); }
+        if (tokenSecret != 'pfkkdhi9sl3r4s00') { return callback(new Error('incorrect tokenSecret argument')); }
+        if (typeof profile !== 'object') { return done(new Error('incorrect profile argument')); }
+        if (Object.keys(profile).length !== 0) { return done(new Error('incorrect profile argument')); }
+    
+        return done(null, { id: '1234' }, { message: 'Hello' });
+      });
+    
+      strategy._oauth.getOAuthAccessToken = function(token, tokenSecret, verifier, callback) {
+        if (token != 'hh5s93j4hdidpola') { return callback(new Error('incorrect token argument')); }
+        if (tokenSecret != 'hdhd0244k9j7ao03') { return callback(new Error('incorrect tokenSecret argument')); }
+        if (verifier != 'hfdp7dh39dks9884') { return callback(new Error('incorrect verifier argument')); }
+        
+        return callback(null, 'nnch734d00sl2jdk', 'pfkkdhi9sl3r4s00', {});
+      };
+    
+    
+      var request
+        , user
+        , info;
+  
+      before(function(done) {
+        chai.passport.use(strategy)
+          .success(function(u, i) {
+            user = u;
+            info = i;
+            done();
+          })
+          .req(function(req) {
+            request = req;
+            req.query = {};
+            req.query['oauth_token'] = 'hh5s93j4hdidpola';
+            req.query['oauth_verifier'] = 'hfdp7dh39dks9884';
+            req.session = {};
+            req.session['oauth'] = {};
+            req.session['oauth']['oauth_token'] = 'hh5s93j4hdidpola';
+            req.session['oauth']['oauth_token_secret'] = 'hdhd0244k9j7ao03';
+            req.session['oauth']['state'] = { beep: 'boop' };
+          })
+          .authenticate();
+      });
+  
+      it('should supply user', function() {
+        expect(user).to.be.an.object;
+        expect(user.id).to.equal('1234');
+      });
+
+      it('should supply info', function() {
+        expect(info).to.be.an.object;
+        expect(info.message).to.equal('Hello');
+        expect(info.state).to.deep.equal({ beep: 'boop' });
+      });
+    
+      it('should remove token and token secret from session', function() {
+        expect(request.session['oauth']).to.be.undefined;
+      });
+    }); // that was approved with state
+    
+  });
+  
+});


### PR DESCRIPTION
This PR implements support for storing application-level state, provided as an option to `passport.authenticate()`.

```
passport.authenticate('twitter', { state: { beep: 'boop' } });
```